### PR TITLE
Add support for installation on CoreOS.

### DIFF
--- a/src/install-full.sh
+++ b/src/install-full.sh
@@ -796,7 +796,7 @@ setup_auto_update() {
     if [ -d /etc/cron.d ]; then
       echo "* * * * * ${USERNAME} ${updateScript} --cron > /dev/null 2>&1 || true" > /etc/cron.d/unms-update
     else
-      echo >&2 "WARNING: Failed to enable auto update as /etc/cron.d folder is not present. Is crontab missing?"
+      echo >&2 "Failed to enable auto update as /etc/cron.d folder is not present. Is crontab missing?"
       exit 1
     fi
 

--- a/src/install-full.sh
+++ b/src/install-full.sh
@@ -395,11 +395,6 @@ check_system() {
 
   esac
 
-  if [ ! which curl > /dev/null 2>&1 ] && [ ! which wget > /dev/null 2>&1 ]; then
-    echo >&2 "This script requires eithr 'curl' or 'wget'. Please install try again. Aborting."
-    exit 1
-  fi
-
   for prerequisite in "${PREREQUISITES[@]}"; do
     IFS=\| read -r preCommand prePackage <<< "${prerequisite}"
     command -v "${preCommand}" >/dev/null 2>&1 || {
@@ -892,13 +887,7 @@ confirm_success() {
   do
     sleep 3s
     unmsRunning=true
-
-    if (which curl > /dev/null 2>&1); then
-      curl -skL "https://127.0.0.1:${HTTPS_PORT}" > /dev/null && break
-    elif (which wget > /dev/null 2>&1); then
-      wget -q --no-check-certificate "https://127.0.0.1:${HTTPS_PORT}" && break
-    fi
-
+    curl -skL "https://127.0.0.1:${HTTPS_PORT}" > /dev/null && break
     echo "."
     unmsRunning=false
     n=$((n+1))

--- a/src/install-full.sh
+++ b/src/install-full.sh
@@ -395,8 +395,8 @@ check_system() {
 
   esac
 
-  if [ ! which nc > /dev/null 2>&1 ] && [ ! which curl > /dev/null 2>&1 ] && [ ! which wget > /dev/null 2>&1 ]; then
-    echo >&2 "This script requires eithr 'nc', 'curl' or 'wget'. Please install try again. Aborting."
+  if [ ! which curl > /dev/null 2>&1 ] && [ ! which wget > /dev/null 2>&1 ]; then
+    echo >&2 "This script requires eithr 'curl' or 'wget'. Please install try again. Aborting."
     exit 1
   fi
 
@@ -802,6 +802,7 @@ setup_auto_update() {
       echo "* * * * * ${USERNAME} ${updateScript} --cron > /dev/null 2>&1 || true" > /etc/cron.d/unms-update
     else
       echo >&2 "WARNING: Failed to enable auto update as /etc/cron.d folder is not present. Is crontab missing?"
+      exit 1
     fi
 
   fi
@@ -892,9 +893,7 @@ confirm_success() {
     sleep 3s
     unmsRunning=true
 
-    if (which nc > /dev/null 2>&1); then
-      nc -z 127.0.0.1 "${HTTPS_PORT}" && break
-    elif (which curl > /dev/null 2>&1); then
+    if (which curl > /dev/null 2>&1); then
       curl -skL "https://127.0.0.1:${HTTPS_PORT}" > /dev/null && break
     elif (which wget > /dev/null 2>&1); then
       wget -q --no-check-certificate "https://127.0.0.1:${HTTPS_PORT}" && break


### PR DESCRIPTION
Update docker-compose install to install in a location that is writeable.
Update fixed path for docker-compose in build_docker_images
Update confirm_success to use either nc, curl or wget
Update setup_auto_update to use the /etc/cron.d folder while have no requirement for crontab binary
Update check_system to check for CoreOS distribution and set docker compose path to writeable path.

Fixes #103 