### PR TITLE
Hide nginx version

### DIFF
--- a/src/nginx/nginx.conf.template
+++ b/src/nginx/nginx.conf.template
@@ -25,6 +25,7 @@ http {
   default_type application/octet-stream;
   access_log off;
   sendfile on;
+  server_tokens off;
 
   set_real_ip_from  ${LOCAL_NETWORK};
   real_ip_header    X-Forwarded-For;


### PR DESCRIPTION
Servers will commonly reveal what software is running on them, what versions of the software are on there and what frameworks are powering it. Reducing the amount of information you divulge is always a benefit.