### PR TITLE
Change docker-compose command in umns-cli to allow for  docker-compose override

### DIFF
--- a/src/unms-cli
+++ b/src/unms-cli
@@ -10,7 +10,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 APP_DIR="${SCRIPT_DIR}"
 HOME_DIR="$(readlink -f "${APP_DIR}/..")"
 DATA_DIR="$(readlink -f "${HOME_DIR}/data")"
-DOCKER_COMPOSE_FILE="${APP_DIR}/docker-compose.yml"
 CONF_FILE="${APP_DIR}/unms.conf"
 COMPOSE_PROJECT_NAME="unms"
 
@@ -79,7 +78,7 @@ failWithCommandUsage() {
 }
 
 dockerCompose() {
-  docker-compose -p "${COMPOSE_PROJECT_NAME}" -f "${DOCKER_COMPOSE_FILE}" "$@"
+  docker-compose -p "${COMPOSE_PROJECT_NAME}" --project-directory "${APP_DIR}" "$@"
 }
 
 isRunning() {


### PR DESCRIPTION
Hello,

this PR proposes a change to unms-cli which specifies the docker-compose project directory instead of the specific compose file, allowing for normal docker-compose override mechanics to work again, which in turn allows for local tweaks to the docker-compose configuration without breaking the update automation.

if it helps, an example use case for such a tweak: adding the stack to an external docker network to use a shared proxy
